### PR TITLE
Fixed typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,7 +263,7 @@
 			<b>1. Pequeñas tendencias individuales &rarr; Grandes tendencias colectivas.</b>
 			<br>
 			<!--Micromotives, macrobehaviour...-->
-			Cuando alguien dice que la cultura es formófoba, no están diciendo que los <i>individos</i> en ella son formófobos.
+			Cuando alguien dice que la cultura es formófoba, no están diciendo que los <i>individuos</i> en ella son formófobos.
 			No te están atacando a vos personalmente.
 		</p>
 		<p>


### PR DESCRIPTION
Fixed typo in Spanish language. Changed 'individos' to 'individuos'.
